### PR TITLE
Make tnetstring compatible with upcoming Rust version (>0.6)

### DIFF
--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -8,7 +8,6 @@
 extern mod std;
 
 use core::io::{ReaderUtil, WriterUtil};
-use core::from_str::FromStr;
 
 /// Represents a TNetString value.
 pub enum TNetString {

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -8,7 +8,6 @@
 extern mod std;
 
 use core::io::{ReaderUtil, WriterUtil};
-use std::rand;
 use core::from_str::FromStr;
 
 /// Represents a TNetString value.

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -7,7 +7,7 @@
 
 extern mod std;
 
-use io::{ReaderUtil, WriterUtil};
+use core::io::{ReaderUtil, WriterUtil};
 use std::rand;
 
 /// Represents a TNetString value.

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -191,7 +191,7 @@ fn parse_pair(reader: io::Reader) -> (~[u8], TNetString) {
 }
 
 fn parse_map(data: &[u8]) -> ~core::hashmap::HashMap<~[u8], TNetString> {
-    let mut result = ~core::hashmap::HashMap();
+    let mut result = ~core::hashmap::HashMap::new();
 
     if data.len() != 0u {
         do io::with_bytes_reader(data) |reader| {

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -238,7 +238,9 @@ impl cmp::Eq for TNetString {
             (&Map(ref d0), &Map(ref d1)) => {
                 if d0.len() == d1.len() {
                     for d0.each |k0, v0| {
-                        let result = match d1.find_ref(k0) {
+                        // XXX send_map::linear::LinearMap has find_ref, but
+                        // that method is not available for HashMap.
+                        let result = match d1.find(k0) {
                             Some(v1) => v0 == v1,
                             None => false,
                         };

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -24,8 +24,8 @@ pub enum TNetString {
 pub type Map = ~core::hashmap::HashMap<~[u8], TNetString>;
 
 /// Serializes a TNetString value into a io::Writer.
-pub fn to_writer(writer: io::Writer, tnetstring: &TNetString) {
-    fn write_str(wr: io::Writer, s: &[u8]) {
+pub fn to_writer(writer: @io::Writer, tnetstring: &TNetString) {
+    fn write_str(wr: @io::Writer, s: &[u8]) {
         wr.write_str(fmt!("%u:", s.len()));
         wr.write(s);
         wr.write_char(',');
@@ -85,7 +85,7 @@ impl to_str::ToStr for TNetString {
 }
 
 /// Deserializes a TNetString value from an io::Reader.
-pub fn from_reader(reader: io::Reader) -> Option<TNetString> {
+pub fn from_reader(reader: @io::Reader) -> Option<TNetString> {
     assert!(!reader.eof());
 
     let mut c = reader.read_byte();
@@ -177,7 +177,7 @@ fn parse_vec(data: &[u8]) -> ~[TNetString] {
     }
 }
 
-fn parse_pair(reader: io::Reader) -> (~[u8], TNetString) {
+fn parse_pair(reader: @io::Reader) -> (~[u8], TNetString) {
     match from_reader(reader) {
         Some(Str(key)) => {
             match from_reader(reader) {

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -89,7 +89,7 @@ pub impl TNetString: to_str::ToStr {
 
 /// Deserializes a TNetString value from an io::Reader.
 pub fn from_reader(reader: io::Reader) -> Option<TNetString> {
-    assert !reader.eof();
+    assert!(!reader.eof());
 
     let mut c = reader.read_byte();
     let mut len = 0u;
@@ -147,7 +147,7 @@ pub fn from_reader(reader: io::Reader) -> Option<TNetString> {
         float::from_str(s).map(|v| Float(*v))
       }
       '~' => {
-        assert payload.len() == 0u;
+        assert!(payload.len() == 0u);
         Some(Null)
       }
       ',' => Some(Str(move payload)),
@@ -268,12 +268,12 @@ mod tests {
 
     fn test(s: &~str, expected: &TNetString) {
         let (actual, rest) = from_str(*s);
-        assert actual.is_some();
-        assert rest == ~"";
+        assert!(actual.is_some());
+        assert!(rest == ~"");
 
         let actual = option::unwrap(move actual);
-        assert actual == *expected;
-        assert expected.to_str() == *s;
+        assert!(actual == *expected);
+        assert!(expected.to_str() == *s);
     }
 
     #[test]
@@ -400,10 +400,10 @@ mod tests {
         let mut i = 500u;
         while i != 0u {
             let v0 = get_random_object(rng, 0u32);
-            
+
             match from_bytes(to_bytes(&v0)) {
                 (Some(ref v1), ref rest) if *rest == ~[] => {
-                    assert v0 == *v1
+                    assert!(v0 == *v1)
                 },
                 _ => fail ~"invalid TNetString"
             }

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -97,7 +97,7 @@ pub fn from_reader(reader: io::Reader) -> Option<TNetString> {
     // Note that netstring spec explicitly forbids padding zeros.
     // If the first char is zero, it must be the only char.
     if c < '0' as int || c > '9' as int {
-        fail ~"Not a TNetString: invalid or missing length prefix";
+        fail!(~"Not a TNetString: invalid or missing length prefix");
     } else if c == '0' as int {
         c = reader.read_byte();
     } else {
@@ -105,7 +105,7 @@ pub fn from_reader(reader: io::Reader) -> Option<TNetString> {
             len = (10u * len) + ((c as uint) - ('0' as uint));
 
             if reader.eof() {
-                fail ~"Not a TNetString: invalid or missing length prefix";
+                fail!(~"Not a TNetString: invalid or missing length prefix");
             }
             c = reader.read_byte();
 
@@ -117,18 +117,18 @@ pub fn from_reader(reader: io::Reader) -> Option<TNetString> {
 
     // Validate end-of-length-prefix marker.
     if c != ':' as int {
-        fail ~"Not a TNetString: missing length prefix";
+        fail!(~"Not a TNetString: missing length prefix");
     }
 
     // Read the data plus terminating type tag.
     let payload = reader.read_bytes(len);
 
     if payload.len() != len {
-        fail ~"Not a TNetString: invalid length prefix";
+        fail!(~"Not a TNetString: invalid length prefix");
     }
 
     if reader.eof() {
-        fail ~"Not a TNetString: missing type tag";
+        fail!(~"Not a TNetString: missing type tag");
     }
 
     match reader.read_byte() as char {
@@ -153,7 +153,7 @@ pub fn from_reader(reader: io::Reader) -> Option<TNetString> {
       ',' => Some(Str(move payload)),
       c => {
         let s = str::from_char(c);
-        fail fmt!("Invalid payload type: %?", s)
+        fail!(fmt!("Invalid payload type: %?", s))
       }
     }
 }
@@ -166,13 +166,13 @@ fn parse_vec(data: &[u8]) -> ~[TNetString] {
 
         match move from_reader(reader) {
             Some(move value) => result.push(move value),
-            None => fail ~"invalid value"
+            None => fail!(~"invalid value")
         }
 
         while !reader.eof() {
             match move from_reader(reader) {
                 Some(move value) => result.push(move value),
-                None => fail ~"invalid TNetString"
+                None => fail!(~"invalid TNetString")
             }
         }
 
@@ -185,11 +185,11 @@ fn parse_pair(reader: io::Reader) -> (~[u8], TNetString) {
         Some(Str(move key)) => {
             match from_reader(reader) {
                 Some(move value) => (move key, move value),
-                None => fail ~"invalid TNetString",
+                None => fail!(~"invalid TNetString"),
             }
         }
-        Some(_) => fail ~"Keys can only be strings.",
-        None => fail ~"Invalid TNetString",
+        Some(_) => fail!(~"Keys can only be strings."),
+        None => fail!(~"Invalid TNetString"),
     }
 }
 
@@ -377,7 +377,7 @@ mod tests {
                             if f == f1 { break; }
                             f = f1;
                           }
-                          None => fail ~"invalid float"
+                          None => fail!(~"invalid float")
                         }
                     }
 
@@ -405,7 +405,7 @@ mod tests {
                 (Some(ref v1), ref rest) if *rest == ~[] => {
                     assert!(v0 == *v1)
                 },
-                _ => fail ~"invalid TNetString"
+                _ => fail!(~"invalid TNetString")
             }
             i -= 1u;
         }

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -9,6 +9,7 @@ extern mod std;
 
 use core::io::{ReaderUtil, WriterUtil};
 use std::rand;
+use core::from_str::FromStr;
 
 /// Represents a TNetString value.
 pub enum TNetString {
@@ -137,7 +138,7 @@ pub fn from_reader(reader: io::Reader) -> Option<TNetString> {
       ']' => Some(Vec(parse_vec(payload))),
       '!' => {
         let s = unsafe { str::raw::from_bytes(payload) };
-        bool::from_str(s).map(|v| Bool(*v))
+        FromStr::from_str(s).map(|v| Bool(*v))
       }
       '^' => {
         let s = unsafe { str::raw::from_bytes(payload) };

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -34,7 +34,7 @@ pub fn to_writer(writer: io::Writer, tnetstring: &TNetString) {
     match tnetstring {
         &Str(ref s) => write_str(writer, *s),
         &Int(i) => {
-            let s = int::str(i);
+            let s = int::to_str(i);
             writer.write_str(fmt!("%u:%s#", s.len(), s));
         }
         &Float(f) => {

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -7,8 +7,6 @@
 
 extern mod std;
 
-use core::io::{ReaderUtil, WriterUtil};
-
 /// Represents a TNetString value.
 pub enum TNetString {
     Str(~[u8]),

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -76,10 +76,10 @@ pub fn to_bytes(tnetstring: &TNetString) -> ~[u8] {
 }
 
 /// Serializes a TNetString value into a string.
-pub impl TNetString: to_str::ToStr {
-    fn to_str() -> ~str {
+impl to_str::ToStr for TNetString {
+    fn to_str(&self) -> ~str {
         do io::with_str_writer |wr| {
-            to_writer(wr, &self);
+            to_writer(wr, self);
         }
     }
 }
@@ -227,7 +227,7 @@ pub fn from_str(data: &str) -> (Option<TNetString>, ~str) {
 }
 
 /// Test the equality between two TNetString values
-pub impl TNetString: cmp::Eq {
+impl cmp::Eq for TNetString {
     fn eq(&self, other: &TNetString) -> bool {
         match (self, other) {
             (&Str(ref s0), &Str(ref s1)) => s0 == s1,

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -147,7 +147,7 @@ pub fn from_reader(reader: io::Reader) -> Option<TNetString> {
         assert!(payload.len() == 0u);
         Some(Null)
       }
-      ',' => Some(Str(move payload)),
+      ',' => Some(Str(payload)),
       c => {
         let s = str::from_char(c);
         fail!(fmt!("Invalid payload type: %?", s))
@@ -161,27 +161,27 @@ fn parse_vec(data: &[u8]) -> ~[TNetString] {
     do io::with_bytes_reader(data) |reader| {
         let mut result = ~[];
 
-        match move from_reader(reader) {
-            Some(move value) => result.push(move value),
+        match from_reader(reader) {
+            Some(value) => result.push(value),
             None => fail!(~"invalid value")
         }
 
         while !reader.eof() {
-            match move from_reader(reader) {
-                Some(move value) => result.push(move value),
+            match from_reader(reader) {
+                Some(value) => result.push(value),
                 None => fail!(~"invalid TNetString")
             }
         }
 
-        move result
+        result
     }
 }
 
 fn parse_pair(reader: io::Reader) -> (~[u8], TNetString) {
     match from_reader(reader) {
-        Some(Str(move key)) => {
+        Some(Str(key)) => {
             match from_reader(reader) {
-                Some(move value) => (move key, move value),
+                Some(value) => (key, value),
                 None => fail!(~"invalid TNetString"),
             }
         }
@@ -196,23 +196,23 @@ fn parse_map(data: &[u8]) -> ~send_map::linear::LinearMap<~[u8], TNetString> {
     if data.len() != 0u {
         do io::with_bytes_reader(data) |reader| {
             let (key, value) = parse_pair(reader);
-            result.insert(move key, move value);
+            result.insert(key, value);
 
             while !reader.eof() {
                 let (key, value) = parse_pair(reader);
-                result.insert(move key, move value);
+                result.insert(key, value);
             }
         }
     }
 
-    move result
+    result
 }
 
 /// Deserializes a TNetString value from a byte string.
 pub fn from_bytes(data: &[u8]) -> (Option<TNetString>, ~[u8]) {
     do io::with_bytes_reader(data) |reader| {
         let tnetstring = from_reader(reader);
-        (move tnetstring, reader.read_whole_stream())
+        (tnetstring, reader.read_whole_stream())
     }
 }
 
@@ -221,7 +221,7 @@ pub fn from_str(data: &str) -> (Option<TNetString>, ~str) {
     do io::with_str_reader(data) |rdr| {
         let tnetstring = from_reader(rdr);
         let bytes = rdr.read_whole_stream();
-        (move tnetstring, str::from_bytes(bytes))
+        (tnetstring, str::from_bytes(bytes))
     }
 
 }
@@ -268,7 +268,7 @@ mod tests {
         assert!(actual.is_some());
         assert!(rest == ~"");
 
-        let actual = option::unwrap(move actual);
+        let actual = option::unwrap(actual);
         assert!(actual == *expected);
         assert!(expected.to_str() == *s);
     }
@@ -289,7 +289,7 @@ mod tests {
                     Str(str::to_bytes("\x00\x00\x00\x00"))]));
 
         test(&~"51:5:hello,39:11:12345678901#4:this,4:true!0:~4:\x00\x00\x00\
-               \x00,]}", &Map(move d));
+               \x00,]}", &Map(d));
 
         test(&~"5:12345#", &Int(12345));
         test(&~"12:this is cool,", &Str(str::to_bytes("this is cool")));
@@ -344,12 +344,12 @@ mod tests {
                     while i != 0u32 {
                         let s = rng.gen_bytes(randint(rng, 0u32, 100u32) as uint);
                         d.insert(
-                            move s,
-                            move get_random_object(rng, depth + 1u32)
+                            s,
+                            get_random_object(rng, depth + 1u32)
                         );
                         i -= 1u32;
                     }
-                    Map(move d)
+                    Map(d)
                 }
             } else {
                 match randint(rng, 0u32, 5u32) {

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -38,7 +38,7 @@ pub fn to_writer(writer: @io::Writer, tnetstring: &TNetString) {
             writer.write_str(fmt!("%u:%s#", s.len(), s));
         }
         &Float(f) => {
-            let s = float::to_str(f, 6u);
+            let s = float::to_str_digits(f, 6u);
             writer.write_str(fmt!("%u:%s^", s.len(), s));
         }
         &Bool(b) => {
@@ -369,7 +369,7 @@ mod tests {
                     // Generate a float that can be exactly converted to
                     // and from a string.
                     loop {
-                        match float::from_str(float::to_str(f, 6u)) {
+                        match float::from_str(float::to_str_digits(f, 6u)) {
                           Some(f1) => {
                             if f == f1 { break; }
                             f = f1;

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -44,7 +44,7 @@ pub fn to_writer(writer: @io::Writer, tnetstring: &TNetString) {
         }
         &Map(ref m) => {
             let payload = do io::with_bytes_writer |wr| {
-                for m.each |key, value| {
+                for m.iter().advance |(key, value)| {
                     write_str(wr, *key);
                     to_writer(wr, value);
                 }
@@ -55,7 +55,7 @@ pub fn to_writer(writer: @io::Writer, tnetstring: &TNetString) {
         }
         &Vec(ref v) => {
             let payload = do io::with_bytes_writer |wr| {
-                for v.each |e| { to_writer(wr, e) }
+                for v.iter().advance |e| { to_writer(wr, e) }
             };
             writer.write_str(fmt!("%u:", payload.len()));
             writer.write(payload);
@@ -234,7 +234,7 @@ impl cmp::Eq for TNetString {
             (&Null, &Null) => true,
             (&Map(ref d0), &Map(ref d1)) => {
                 if d0.len() == d1.len() {
-                    for d0.each |k0, v0| {
+                    for d0.iter().advance |(k0, v0)| {
                         // XXX send_map::linear::LinearMap has find_ref, but
                         // that method is not available for HashMap.
                         let result = match d1.find(k0) {

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -18,7 +18,7 @@ pub enum TNetString {
     Vec(~[TNetString]),
 }
 
-pub type Map = ~core::hashmap::HashMap<~[u8], TNetString>;
+pub type Map = ~std::hashmap::HashMap<~[u8], TNetString>;
 
 /// Serializes a TNetString value into a io::Writer.
 pub fn to_writer(writer: @io::Writer, tnetstring: &TNetString) {
@@ -187,8 +187,8 @@ fn parse_pair(reader: @io::Reader) -> (~[u8], TNetString) {
     }
 }
 
-fn parse_map(data: &[u8]) -> ~core::hashmap::HashMap<~[u8], TNetString> {
-    let mut result = ~core::hashmap::HashMap::new();
+fn parse_map(data: &[u8]) -> ~std::hashmap::HashMap<~[u8], TNetString> {
+    let mut result = ~std::hashmap::HashMap::new();
 
     if data.len() != 0u {
         do io::with_bytes_reader(data) |reader| {
@@ -275,10 +275,10 @@ mod tests {
     #[test]
     fn test_format() {
         test(&~"11:hello world,", &Str(str::to_bytes("hello world")));
-        test(&~"0:}", &Map(~core::hashmap::HashMap()));
+        test(&~"0:}", &Map(~std::hashmap::HashMap()));
         test(&~"0:]", &Vec(~[]));
 
-        let mut d = ~core::hashmap::HashMap();
+        let mut d = ~std::hashmap::HashMap();
         d.insert(str::to_bytes("hello"),
                 Vec(~[
                     Int(12345678901),
@@ -337,7 +337,7 @@ mod tests {
                         get_random_object(rng, depth + 1u32)
                     ))
                 } else {
-                    let mut d = ~core::hashmap::HashMap();
+                    let mut d = ~std::hashmap::HashMap();
 
                     let mut i = randint(rng, 0u32, 10u32);
                     while i != 0u32 {

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -21,7 +21,7 @@ pub enum TNetString {
     Vec(~[TNetString]),
 }
 
-pub type Map = ~send_map::linear::LinearMap<~[u8], TNetString>;
+pub type Map = ~core::hashmap::HashMap<~[u8], TNetString>;
 
 /// Serializes a TNetString value into a io::Writer.
 pub fn to_writer(writer: io::Writer, tnetstring: &TNetString) {
@@ -190,8 +190,8 @@ fn parse_pair(reader: io::Reader) -> (~[u8], TNetString) {
     }
 }
 
-fn parse_map(data: &[u8]) -> ~send_map::linear::LinearMap<~[u8], TNetString> {
-    let mut result = ~send_map::linear::LinearMap();
+fn parse_map(data: &[u8]) -> ~core::hashmap::HashMap<~[u8], TNetString> {
+    let mut result = ~core::hashmap::HashMap();
 
     if data.len() != 0u {
         do io::with_bytes_reader(data) |reader| {
@@ -276,10 +276,10 @@ mod tests {
     #[test]
     fn test_format() {
         test(&~"11:hello world,", &Str(str::to_bytes("hello world")));
-        test(&~"0:}", &Map(~send_map::linear::LinearMap()));
+        test(&~"0:}", &Map(~core::hashmap::HashMap()));
         test(&~"0:]", &Vec(~[]));
 
-        let mut d = ~send_map::linear::LinearMap();
+        let mut d = ~core::hashmap::HashMap();
         d.insert(str::to_bytes("hello"),
                 Vec(~[
                     Int(12345678901),
@@ -338,7 +338,7 @@ mod tests {
                         get_random_object(rng, depth + 1u32)
                     ))
                 } else {
-                    let mut d = ~send_map::linear::LinearMap();
+                    let mut d = ~core::hashmap::HashMap();
 
                     let mut i = randint(rng, 0u32, 10u32);
                     while i != 0u32 {

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -77,12 +77,9 @@ pub fn to_bytes(tnetstring: &TNetString) -> ~[u8] {
 
 /// Serializes a TNetString value into a string.
 pub impl TNetString: to_str::ToStr {
-    pure fn to_str() -> ~str {
-        // FIXME: https://github.com/mozilla/rust/issues/3758
-        unsafe {
-            do io::with_str_writer |wr| {
-                to_writer(wr, &self);
-            }
+    fn to_str() -> ~str {
+        do io::with_str_writer |wr| {
+            to_writer(wr, &self);
         }
     }
 }
@@ -231,7 +228,7 @@ pub fn from_str(data: &str) -> (Option<TNetString>, ~str) {
 
 /// Test the equality between two TNetString values
 pub impl TNetString: cmp::Eq {
-    pure fn eq(&self, other: &TNetString) -> bool {
+    fn eq(&self, other: &TNetString) -> bool {
         match (self, other) {
             (&Str(ref s0), &Str(ref s1)) => s0 == s1,
             (&Int(i0), &Int(i1)) => i0 == i1,
@@ -259,7 +256,7 @@ pub impl TNetString: cmp::Eq {
         }
     }
 
-    pure fn ne(&self, other: &TNetString) -> bool { !self.eq(other) }
+    fn ne(&self, other: &TNetString) -> bool { !self.eq(other) }
 }
 
 #[cfg(test)]

--- a/tnetstring.rc
+++ b/tnetstring.rc
@@ -5,7 +5,7 @@
 
 /// Rust TNetStrings serialization library.
 
-extern mod std;
+use std::{cmp, float, int, io, str, to_str};
 
 /// Represents a TNetString value.
 pub enum TNetString {
@@ -31,7 +31,7 @@ pub fn to_writer(writer: @io::Writer, tnetstring: &TNetString) {
     match tnetstring {
         &Str(ref s) => write_str(writer, *s),
         &Int(i) => {
-            let s = int::to_str(i);
+            let s = i.to_str();
             writer.write_str(fmt!("%u:%s#", s.len(), s));
         }
         &Float(f) => {
@@ -39,7 +39,7 @@ pub fn to_writer(writer: @io::Writer, tnetstring: &TNetString) {
             writer.write_str(fmt!("%u:%s^", s.len(), s));
         }
         &Bool(b) => {
-            let s = bool::to_str(b);
+            let s = b.to_str();
             writer.write_str(fmt!("%u:%s!", s.len(), s));
         }
         &Map(ref m) => {
@@ -249,7 +249,7 @@ impl cmp::Eq for TNetString {
                 }
             }
             (&Vec(ref v0), &Vec(ref v1)) => {
-                vec::all2(*v0, *v1, |x0, x1| x0 == x1)
+                v0.eq(v1)
             },
             _ => false
         }


### PR DESCRIPTION
The upcoming Rust version is for some parts of the Rust language not compatible with older versions:
- Various keywords are dropped (move, pure, fail / assert macros).
- Rename LinearMap -> HashMap.
- LinearMap::find_ref() is dropped. I used HashMap::find() instead.
- Fix implementation syntax (double colon is deprecated).
-  Various core library function changes.

I compiled tnetstring successfully with this Rust version:
$ rustc -v
rustc 0.6 (2d28d64 2013-05-17 15:52:25 -0700)
host: x86_64-unknown-linux-gnu
